### PR TITLE
Fix word matching in custom regex engine

### DIFF
--- a/Regular Expression Engine/regex.js
+++ b/Regular Expression Engine/regex.js
@@ -335,40 +335,21 @@ function createMatcher(exp, kelime) {
   const postfixRegex = postfixDonusumu(concatliRegex);
   console.log(postfixRegex);
   const nfa = NFADonusumu(postfixRegex);
-  
-  // str = JSON.stringify(nfa);
-  // str = JSON.stringify(nfa, null, 4); // (Optional) beautiful indented output.
-  // console.log(str);
-  
-  let string = "";
-  let token;
 
-  for(let i = 0; i<kelime.length; i++)
-  {
-    token = kelime[i];
+  const result = document.getElementById("sonuc");
+  while (result.firstChild) {
+    result.removeChild(result.firstChild);
+  }
 
-    if (token === " ")
-    {
-      while (i + 1 < kelime.length && kelime[i + 1] === " ") {
-        i++;
-      }
-      string = "";
-      continue;
-    }
+  const words = kelime.split(/\s+/).filter(Boolean);
 
-    string += token;
-
-    if(hatirla(nfa, string))
-    {
-      const result = document.getElementById("sonuc");
+  for (const word of words) {
+    if (hatirla(nfa, word)) {
       const div = document.createElement("div");
-      div.textContent = string;
+      div.textContent = word;
       result.appendChild(div);
     }
-
   }
-  
-
-  //console.log(hatirla(nfa, kelime));
 }
+
 


### PR DESCRIPTION
## Summary
- simplify the matcher logic
- check each whitespace-separated token against the regex

## Testing
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
const code=fs.readFileSync('Regular Expression Engine/regex.js','utf8');
vm.runInThisContext(code);
const nfa=NFADonusumu(postfixDonusumu(concatOperatoruEkle('(ab)|(ba)')));
const words='abababab a ab ba'.split(/\s+/).filter(Boolean);
console.log(words.map(w=>hatirla(nfa,w)));
NODE`
