### PR TITLE
Highlight regex matches within text

### DIFF
--- a/Regular Expression Engine/regex.js
+++ b/Regular Expression Engine/regex.js
@@ -341,15 +341,18 @@ function createMatcher(exp, kelime) {
     result.removeChild(result.firstChild);
   }
 
-  const words = kelime.split(/\s+/).filter(Boolean);
+  const tokens = kelime.split(/(\s+)/);
+  let output = "";
 
-  for (const word of words) {
-    if (hatirla(nfa, word)) {
-      const div = document.createElement("div");
-      div.textContent = word;
-      result.appendChild(div);
+  for (const token of tokens) {
+    if (token.trim() && hatirla(nfa, token)) {
+      output += `<mark>${token}</mark>`;
+    } else {
+      output += token;
     }
   }
+
+  result.innerHTML = output;
 }
 
 

--- a/Regular Expression Engine/style2.css
+++ b/Regular Expression Engine/style2.css
@@ -119,3 +119,4 @@ textarea {
     width: 120%;
     color:black ;
 }
+mark { background-color: yellow; }


### PR DESCRIPTION
## Summary
- highlight matched words inside the text
- add simple highlight style

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m unittest`
