### PR TITLE
Add DFA conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Regular-Expression-Engine
 A small JavaScript based regular expression engine that demonstrates
-pattern searching with NFA and DFA techniques.  Only a limited subset
+pattern searching with NFA and DFA techniques.  The matcher first
+builds an NFA using Thompson's construction and then converts it to a
+DFA for searching. Only a limited subset
 of regular expression syntax is implemented but it is enough to show
 how state machines work.
 
@@ -9,7 +11,8 @@ how state machines work.
 1. Open `index.html` or `indexC.html` in a modern web browser.
 2. Enter a regular expression and the text to search.
 3. Click **NFA** to run the matcher and view the results under the
-   search box.
+   search box.  Internally the NFA is converted to a DFA before the
+   search is performed.
 
 Currently the engine supports literals, `+`, `*`, parentheses and `|`.
 


### PR DESCRIPTION
## Summary
- convert Thompson NFA to DFA using subset construction
- add DFA based matching in `createMatcher`
- clarify DFA usage in README

## Testing
- `node - <<'EOF'
const fs=require('fs');
const vm=require('vm');
const ctx={console};
vm.createContext(ctx);
vm.runInContext(fs.readFileSync('Regular Expression Engine/regex.js','utf8'), ctx);
const concatliRegex=ctx.concatOperatoruEkle('ab*');
const postfix=ctx.postfixDonusumu(concatliRegex);
const nfa=ctx.NFADonusumu(postfix);
const dfa=ctx.NFAToDFA(nfa);
console.log('states', Object.keys(dfa.dfaStates).length);
console.log(ctx.dfaAra(dfa,'abbb'));
console.log(ctx.dfaAra(dfa,'ac'));
EOF